### PR TITLE
Adding support for multiple environment (dev purpose)

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,0 @@
-{
-  "projects": {
-    "default": "cla-manager-bf923"
-  }
-}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+# CLAM (CLA Manager)
+
+## Setting up a development environment
+
+If you don't have one, create an application on [Firebase](https://console.firebase.google.com/).
+
+
+Once you have it, you'll need to keep track of the `Project ID` and `Web API Key` (You can find them in the `Settings` panel).
+You'll also need to setup Email/Password authentication in the `Authentication` panel.
+
+Once this is done you can start the application with the following command:
+
+```bash
+REACT_APP_FIREBASE_ENV=<ProjectId> REACT_APP_FIREBASE_API_KEY=<WebApiKey> npm start
+```
+
+
+# TLDR;
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts

--- a/src/index.js
+++ b/src/index.js
@@ -8,15 +8,22 @@ import 'firebase/firestore';
 import './index.css';
 import AppRouter from './js/AppRouter';
 import { HandleSignInLink } from './js/SignIn';
+import { HandleDevError } from './js/DevError';
+
+if (!process.env.REACT_APP_FIREBASE_ENV || !process.env.REACT_APP_FIREBASE_API_KEY) {
+  console.error("Environments var missing! Please refer to the README file")
+  // TODO render a stupid component
+  HandleDevError(c => ReactDOM.render(c, document.getElementById('root')));
+}
 
 firebase.initializeApp({
-    "apiKey": "AIzaSyDai4LocdZpoa0t219SDqOEQ4ipMQVOVvQ",
-    "databaseURL": "https://cla-manager-bf923.firebaseio.com",
-    "storageBucket": "cla-manager-bf923.appspot.com",
-    "authDomain": "cla-manager-bf923.firebaseapp.com",
+    "apiKey": process.env.REACT_APP_FIREBASE_API_KEY,
+    "databaseURL": `https://${process.env.REACT_APP_FIREBASE_ENV}.firebaseio.com`,
+    "storageBucket": `${process.env.REACT_APP_FIREBASE_ENV}.appspot.com`,
+    "authDomain": `${process.env.REACT_APP_FIREBASE_ENV}.firebaseapp.com`,
     "messagingSenderId": "232849741230",
-    "projectId": "cla-manager-bf923"
-  });
+    "projectId": `${process.env.REACT_APP_FIREBASE_ENV}`,
+});
 //   firebase.firestore(); // initialize the firestore... why? who knows
 //   console.log(firebase.firestore())
 // firebase.firestore.setLogLevel('debug');

--- a/src/js/DevError.jsx
+++ b/src/js/DevError.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Container from '@material-ui/core/Container';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+import { red } from '@material-ui/core/colors';
+
+const useStyles = makeStyles({
+	card: {
+	  background: red[300],
+	  padding: 30,
+	  marginTop: 100,
+	},
+	pos: {
+	  marginTop: 12,
+	},
+  });
+export default function DevError() {
+	const classes = useStyles();
+	return (
+        <Container component="main" maxWidth="xs">
+			<Card className={classes.card}>
+				<CardContent>
+					<Typography variant="h5" component="h2">
+						Developer error
+					</Typography>
+					<Typography className={classes.pos} color="textSecondary">
+					REACT_APP_FIREBASE_ENV and/or REACT_APP_FIREBASE_API_KEY are missing
+					</Typography>
+				</CardContent>
+			</Card>
+		</Container>
+	)
+}
+
+export async function HandleDevError(fn) {
+	fn(<DevError />)
+}


### PR DESCRIPTION
Adds support for diffent firebase instances when you start the app.
Requires that the client app is started with 
```
REACT_APP_FIREBASE_ENV=<ProjectId> REACT_APP_FIREBASE_API_KEY=<WebApiKey> npm start
```